### PR TITLE
Release v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 - **UUID**: d35379db-88df-4056-af3a-620245f8e347
 - **Name**: multiscales
-- **Schema URL**: "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json"
-- **Spec URL**: "https://github.com/zarr-conventions/multiscales/blob/v1/README.md"
+- **Schema URL**: "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1.0.0/schema.json"
+- **Spec URL**: "https://github.com/zarr-conventions/multiscales/blob/v1.0.0/README.md"
 - **Extension Maturity Classification**: Proposal
 - **Owner**: @emmanuelmathot, @maxrjones, @d-v-b
 
@@ -56,14 +56,6 @@ The configuration in the Zarr convention metadata can be used in these parts of 
 ### Field Details
 
 Additional properties are allowed.
-
-#### version
-
-Multiscales metadata version
-
-* **Type**: `string`
-* **Required**: &#10003; Yes
-* **Pattern**: `^0\.1\.0$`
 
 #### layout
 
@@ -331,8 +323,8 @@ For geospatial data, combine with `proj:*` attributes from [`geo-proj` conventio
   "attributes": {
     "zarr_conventions": [
       {
-        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
-        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1.0.0/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1.0.0/README.md",
         "uuid": "d35379db-88df-4056-af3a-620245f8e347",
         "name": "multiscales",
         "description": "Multiscale layout of zarr datasets"

--- a/examples/array-based-pyramid.json
+++ b/examples/array-based-pyramid.json
@@ -1,44 +1,45 @@
 {
-    "zarr_format": 3,
-    "node_type": "group",
-    "attributes": {
-        "zarr_conventions": [
-            {
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
-                "uuid": "d35379db-88df-4056-af3a-620245f8e347",
-                "name": "multiscales",
-                "description": "Multiscale layout of zarr datasets"
-            }
-        ],
-        "multiscales": {
-            "layout": [
-                {
-                    "asset": "0/data",
-                    "transform": {
-                        "scale": [1.0, 1.0]
-                    }
-                },
-                {
-                    "asset": "1/data",
-                    "derived_from": "0/data",
-                    "transform": {
-                        "scale": [2.0, 2.0],
-                        "translation": [0.5, 0.5]
-                    },
-                    "resampling_method": "average"
-                },
-                {
-                    "asset": "2/data",
-                    "derived_from": "1/data",
-                    "transform": {
-                        "scale": [2.0, 2.0],
-                        "translation": [0.5, 0.5]
-                    },
-                    "resampling_method": "average"
-                }
-            ],
-            "resampling_method": "average"
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1.0.0/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1.0.0/README.md",
+        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets"
+      }
+    ],
+    "multiscales": {
+      "version": "1.0.0",
+      "layout": [
+        {
+          "asset": "0/data",
+          "transform": {
+            "scale": [1.0, 1.0]
+          }
+        },
+        {
+          "asset": "1/data",
+          "derived_from": "0/data",
+          "transform": {
+            "scale": [2.0, 2.0],
+            "translation": [0.5, 0.5]
+          },
+          "resampling_method": "average"
+        },
+        {
+          "asset": "2/data",
+          "derived_from": "1/data",
+          "transform": {
+            "scale": [2.0, 2.0],
+            "translation": [0.5, 0.5]
+          },
+          "resampling_method": "average"
         }
+      ],
+      "resampling_method": "average"
     }
+  }
 }

--- a/examples/custom-pyramid-levels.json
+++ b/examples/custom-pyramid-levels.json
@@ -1,50 +1,51 @@
 {
-    "zarr_format": 3,
-    "node_type": "group",
-    "attributes": {
-        "zarr_conventions": [
-            {
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
-                "uuid": "d35379db-88df-4056-af3a-620245f8e347",
-                "name": "multiscales",
-                "description": "Multiscale layout of zarr datasets"
-            }
-        ],
-        "multiscales": {
-            "layout": [
-                {
-                    "asset": "full",
-                    "transform": {
-                        "scale": [1.0, 1.0],
-                        "translation": [0.0, 0.0]
-                    }
-                },
-                {
-                    "asset": "half",
-                    "derived_from": "full",
-                    "transform": {
-                        "scale": [2.0, 2.0],
-                        "translation": [0.0, 0.0]
-                    }
-                },
-                {
-                    "asset": "quarter",
-                    "derived_from": "half",
-                    "transform": {
-                        "scale": [4.0, 4.0],
-                        "translation": [0.0, 0.0]
-                    }
-                },
-                {
-                    "asset": "eighth",
-                    "derived_from": "quarter",
-                    "transform": {
-                        "scale": [8.0, 8.0],
-                        "translation": [0.0, 0.0]
-                    }
-                }
-            ]
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1.0.0/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1.0.0/README.md",
+        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets"
+      }
+    ],
+    "multiscales": {
+      "version": "1.0.0",
+      "layout": [
+        {
+          "asset": "full",
+          "transform": {
+            "scale": [1.0, 1.0],
+            "translation": [0.0, 0.0]
+          }
+        },
+        {
+          "asset": "half",
+          "derived_from": "full",
+          "transform": {
+            "scale": [2.0, 2.0],
+            "translation": [0.0, 0.0]
+          }
+        },
+        {
+          "asset": "quarter",
+          "derived_from": "half",
+          "transform": {
+            "scale": [4.0, 4.0],
+            "translation": [0.0, 0.0]
+          }
+        },
+        {
+          "asset": "eighth",
+          "derived_from": "quarter",
+          "transform": {
+            "scale": [8.0, 8.0],
+            "translation": [0.0, 0.0]
+          }
         }
+      ]
     }
+  }
 }

--- a/examples/dem-multiresolution.json
+++ b/examples/dem-multiresolution.json
@@ -1,68 +1,69 @@
 {
-    "zarr_format": 3,
-    "node_type": "group",
-    "attributes": {
-        "zarr_conventions": [
-            {
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
-                "uuid": "d35379db-88df-4056-af3a-620245f8e347",
-                "name": "multiscales",
-                "description": "Multiscale layout of zarr datasets"
-            },
-            {
-                "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
-                "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
-                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
-                "name": "proj:",
-                "description": "Coordinate reference system information for geospatial data"
-            }
-        ],
-        "multiscales": {
-            "layout": [
-                {
-                    "asset": "dem_30m",
-                    "transform": {
-                        "scale": [1.0, 1.0],
-                        "translation": [0.0, 0.0]
-                    },
-                    "proj:transform": [0.000277778, 0.0, -180.0, 0.0, -0.000277778, 90.0]
-                },
-                {
-                    "asset": "dem_90m",
-                    "derived_from": "dem_30m",
-                    "transform": {
-                        "scale": [3.0, 3.0],
-                        "translation": [0.0, 0.0]
-                    },
-                    "proj:transform": [0.000833334, 0.0, -180.0, 0.0, -0.000833334, 90.0],
-                    "resampling_method": "average"
-                },
-                {
-                    "asset": "dem_270m",
-                    "derived_from": "dem_90m",
-                    "transform": {
-                        "scale": [3.0, 3.0],
-                        "translation": [0.0, 0.0]
-                    },
-                    "proj:transform": [0.0025, 0.0, -180.0, 0.0, -0.0025, 90.0],
-                    "resampling_method": "average"
-                },
-                {
-                    "asset": "dem_10m_superres",
-                    "derived_from": "dem_30m",
-                    "transform": {
-                        "scale": [0.333, 0.333],
-                        "translation": [0.0, 0.0]
-                    },
-                    "proj:transform": [0.000092593, 0.0, -180.0, 0.0, -0.000092593, 90.0]
-                }
-            ],
-            "resampling_method": "cubic"
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1.0.0/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1.0.0/README.md",
+        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets"
+      },
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
+        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+        "name": "proj:",
+        "description": "Coordinate reference system information for geospatial data"
+      }
+    ],
+    "multiscales": {
+      "version": "1.0.0",
+      "layout": [
+        {
+          "asset": "dem_30m",
+          "transform": {
+            "scale": [1.0, 1.0],
+            "translation": [0.0, 0.0]
+          },
+          "proj:transform": [0.000277778, 0.0, -180.0, 0.0, -0.000277778, 90.0]
         },
-        "proj:code": "EPSG:4326",
-        "proj:spatial_dimensions": ["latitude", "longitude"],
-        "proj:transform": [0.000277778, 0.0, -180.0, 0.0, -0.000277778, 90.0],
-        "proj:bbox": [-180.0, -90.0, 180.0, 90.0]
-    }
+        {
+          "asset": "dem_90m",
+          "derived_from": "dem_30m",
+          "transform": {
+            "scale": [3.0, 3.0],
+            "translation": [0.0, 0.0]
+          },
+          "proj:transform": [0.000833334, 0.0, -180.0, 0.0, -0.000833334, 90.0],
+          "resampling_method": "average"
+        },
+        {
+          "asset": "dem_270m",
+          "derived_from": "dem_90m",
+          "transform": {
+            "scale": [3.0, 3.0],
+            "translation": [0.0, 0.0]
+          },
+          "proj:transform": [0.0025, 0.0, -180.0, 0.0, -0.0025, 90.0],
+          "resampling_method": "average"
+        },
+        {
+          "asset": "dem_10m_superres",
+          "derived_from": "dem_30m",
+          "transform": {
+            "scale": [0.333, 0.333],
+            "translation": [0.0, 0.0]
+          },
+          "proj:transform": [0.000092593, 0.0, -180.0, 0.0, -0.000092593, 90.0]
+        }
+      ],
+      "resampling_method": "cubic"
+    },
+    "proj:code": "EPSG:4326",
+    "proj:spatial_dimensions": ["latitude", "longitude"],
+    "proj:transform": [0.000277778, 0.0, -180.0, 0.0, -0.000277778, 90.0],
+    "proj:bbox": [-180.0, -90.0, 180.0, 90.0]
+  }
 }

--- a/examples/geospatial-pyramid.json
+++ b/examples/geospatial-pyramid.json
@@ -1,59 +1,60 @@
 {
-    "zarr_format": 3,
-    "node_type": "group",
-    "attributes": {
-        "zarr_conventions": [
-            {
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
-                "uuid": "d35379db-88df-4056-af3a-620245f8e347",
-                "name": "multiscales",
-                "description": "Multiscale layout of zarr datasets"
-            },
-            {
-                "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
-                "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
-                "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
-                "name": "proj:",
-                "description": "Coordinate reference system information for geospatial data"
-            }
-        ],
-        "multiscales": {
-            "layout": [
-                {
-                    "asset": "0",
-                    "transform": {
-                        "scale": [1.0, 1.0],
-                        "translation": [0.0, 0.0]
-                    },
-                    "proj:transform": [10.0, 0.0, 500000.0, 0.0, -10.0, 5000000.0]
-                },
-                {
-                    "asset": "1",
-                    "derived_from": "0",
-                    "transform": {
-                        "scale": [2.0, 2.0],
-                        "translation": [0.0, 0.0]
-                    },
-                    "proj:transform": [20.0, 0.0, 500000.0, 0.0, -20.0, 5000000.0],
-                    "resampling_method": "average"
-                },
-                {
-                    "asset": "2",
-                    "derived_from": "1",
-                    "transform": {
-                        "scale": [2.0, 2.0],
-                        "translation": [0.0, 0.0]
-                    },
-                    "proj:transform": [40.0, 0.0, 500000.0, 0.0, -40.0, 5000000.0],
-                    "resampling_method": "average"
-                }
-            ],
-            "resampling_method": "average"
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1.0.0/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1.0.0/README.md",
+        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets"
+      },
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
+        "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
+        "name": "proj:",
+        "description": "Coordinate reference system information for geospatial data"
+      }
+    ],
+    "multiscales": {
+      "version": "1.0.0",
+      "layout": [
+        {
+          "asset": "0",
+          "transform": {
+            "scale": [1.0, 1.0],
+            "translation": [0.0, 0.0]
+          },
+          "proj:transform": [10.0, 0.0, 500000.0, 0.0, -10.0, 5000000.0]
         },
-        "proj:code": "EPSG:32632",
-        "proj:spatial_dimensions": ["Y", "X"],
-        "proj:transform": [10.0, 0.0, 500000.0, 0.0, -10.0, 5000000.0],
-        "proj:bbox": [500000.0, 4900000.0, 600000.0, 5000000.0]
-    }
+        {
+          "asset": "1",
+          "derived_from": "0",
+          "transform": {
+            "scale": [2.0, 2.0],
+            "translation": [0.0, 0.0]
+          },
+          "proj:transform": [20.0, 0.0, 500000.0, 0.0, -20.0, 5000000.0],
+          "resampling_method": "average"
+        },
+        {
+          "asset": "2",
+          "derived_from": "1",
+          "transform": {
+            "scale": [2.0, 2.0],
+            "translation": [0.0, 0.0]
+          },
+          "proj:transform": [40.0, 0.0, 500000.0, 0.0, -40.0, 5000000.0],
+          "resampling_method": "average"
+        }
+      ],
+      "resampling_method": "average"
+    },
+    "proj:code": "EPSG:32632",
+    "proj:spatial_dimensions": ["Y", "X"],
+    "proj:transform": [10.0, 0.0, 500000.0, 0.0, -10.0, 5000000.0],
+    "proj:bbox": [500000.0, 4900000.0, 600000.0, 5000000.0]
+  }
 }

--- a/examples/power-of-2-pyramid.json
+++ b/examples/power-of-2-pyramid.json
@@ -1,45 +1,46 @@
 {
-    "zarr_format": 3,
-    "node_type": "group",
-    "attributes": {
-        "zarr_conventions": [
-            {
-                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
-                "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
-                "uuid": "d35379db-88df-4056-af3a-620245f8e347",
-                "name": "multiscales",
-                "description": "Multiscale layout of zarr datasets"
-            }
-        ],
-        "multiscales": {
-            "layout": [
-                {
-                    "asset": "0",
-                    "transform": {
-                        "scale": [1.0, 1.0],
-                        "translation": [0.0, 0.0]
-                    }
-                },
-                {
-                    "asset": "1",
-                    "derived_from": "0",
-                    "transform": {
-                        "scale": [2.0, 2.0],
-                        "translation": [0.0, 0.0]
-                    },
-                    "resampling_method": "average"
-                },
-                {
-                    "asset": "2",
-                    "derived_from": "1",
-                    "transform": {
-                        "scale": [4.0, 4.0],
-                        "translation": [0.0, 0.0]
-                    },
-                    "resampling_method": "average"
-                }
-            ],
-            "resampling_method": "average"
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1.0.0/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1.0.0/README.md",
+        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets"
+      }
+    ],
+    "multiscales": {
+      "version": "1.0.0",
+      "layout": [
+        {
+          "asset": "0",
+          "transform": {
+            "scale": [1.0, 1.0],
+            "translation": [0.0, 0.0]
+          }
+        },
+        {
+          "asset": "1",
+          "derived_from": "0",
+          "transform": {
+            "scale": [2.0, 2.0],
+            "translation": [0.0, 0.0]
+          },
+          "resampling_method": "average"
+        },
+        {
+          "asset": "2",
+          "derived_from": "1",
+          "transform": {
+            "scale": [4.0, 4.0],
+            "translation": [0.0, 0.0]
+          },
+          "resampling_method": "average"
         }
+      ],
+      "resampling_method": "average"
     }
+  }
 }

--- a/examples/sentinel-2-multiresolution.json
+++ b/examples/sentinel-2-multiresolution.json
@@ -4,8 +4,8 @@
   "attributes": {
     "zarr_conventions": [
       {
-        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
-        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1.0.0/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1.0.0/README.md",
         "uuid": "d35379db-88df-4056-af3a-620245f8e347",
         "name": "multiscales",
         "description": "Multiscale layout of zarr datasets"
@@ -19,6 +19,7 @@
       }
     ],
     "multiscales": {
+      "version": "1.0.0",
       "layout": [
         {
           "asset": "r10m",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "zarr-convention-metadata-template",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "scripts": {
     "test": "node test.js"
   },

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
+  "$id": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1.0.0/schema.json",
   "title": "Multiscales Convention",
   "description": "Schema for multiscale pyramid information in Zarr",
   "type": "object",
@@ -42,12 +42,12 @@
       "properties": {
         "schema_url": {
           "type": "string",
-          "const": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
+          "const": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1.0.0/schema.json",
           "description": "URL to the JSON Schema definition for this convention"
         },
         "spec_url": {
           "type": "string",
-          "const": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
+          "const": "https://github.com/zarr-conventions/multiscales/blob/v1.0.0/README.md",
           "description": "URL to the full specification document"
         },
         "uuid": {
@@ -83,6 +83,11 @@
       "type": "object",
       "description": "Multiscales convention properties defining the hierarchical layout and transformations",
       "properties": {
+        "version": {
+          "type": "string",
+          "description": "Multiscales metadata version",
+          "pattern": "^1\\.0\\.0$"
+        },
         "layout": {
           "type": "array",
           "description": "Array of objects representing the pyramid layout and transformation relationships",
@@ -96,7 +101,7 @@
           "description": "Default resampling method used for downsampling"
         }
       },
-      "required": ["layout"],
+      "required": ["version", "layout"],
       "additionalProperties": true
     },
     "layoutObject": {


### PR DESCRIPTION
Prepare for v1.0.0

Moved from generic `v1` tag to proper semantic versioning with `v1.0.0` to enable systematic version management and clear breaking change detection.


