### PR TITLE
Require uuid in ZCM objects

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -66,17 +66,7 @@
           "description": "Brief description of the convention's purpose and usage"
         }
       },
-      "anyOf": [
-        {
-          "required": ["schema_url"]
-        },
-        {
-          "required": ["spec_url"]
-        },
-        {
-          "required": ["uuid"]
-        }
-      ],
+      "required": ["uuid"],
       "additionalProperties": false
     },
     "multiscalesProperties": {


### PR DESCRIPTION
Since this convention uses UUID as the identifying record, the uuid field must be present and match the expected uuid.